### PR TITLE
merge upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Examples of  *[device libraries](#libraries)* and *[complete projects](#awesome-
 
 The following boards are supported and have been tested with recent releases of Swift:
 
-* Raspberry Pi 4
+* Raspberry Pi 4, 4B
 * Raspberry Pi 3, 3A+, 3B+
 * Raspberry Pi 2 (Thanks to [@iachievedit](https://twitter.com/iachievedit))
 * Raspberry Pi Zero W

--- a/Sources/I2C.swift
+++ b/Sources/I2C.swift
@@ -38,7 +38,8 @@ extension SwiftyGPIO {
              .RaspberryPiRev2,
              .RaspberryPiPlusZero,
              .RaspberryPi2,
-             .RaspberryPi3:
+             .RaspberryPi3,
+             .RaspberryPi4:
             return [I2CRPI[0]!, I2CRPI[1]!]
         default:
             return nil

--- a/Sources/SwiftyGPIO.swift
+++ b/Sources/SwiftyGPIO.swift
@@ -444,7 +444,7 @@ public enum SupportedBoard: String {
     case RaspberryPiPlusZero // Pi A+,B+,Zero with 40 pin header
     case RaspberryPi2 // Pi 2 with 40 pin header
     case RaspberryPi3 // Pi 3 with 40 pin header
-    case RaspberryPi4 // Pi 3 with 40 pin header
+    case RaspberryPi4 // Pi 4 with 40 pin header
     case CHIP
     case BeagleBoneBlack
     case OrangePi


### PR DESCRIPTION
* add .RaspberryPi4 as valid enum case for the same I2C interfaces as Pi3
* addition of Pi 4B to supported boards on README
